### PR TITLE
Add daily stock script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,28 @@ This is my personal summary of **IBM's Introduction to Data Engineering** course
 - `reflections.md` — my insights and personal takeaways
 - ![Data Pipeline Flow](data-eng-diagram.png)
 - `data-eng-diagram.png` — visual of the data pipeline process
+- `daily_stock.py` — script to fetch daily closing prices for a stock symbol
 
 ---
 
 ## ✍️ Built with 💻
 - Markdown
 - GitHub
+- Python
+
+## 🛠 Usage
+
+Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Fetch the latest closing price for a stock symbol:
+
+```bash
+python daily_stock.py AAPL
+```
 
 ## 🚀 Why I’m Doing This
 I want to become a world-class engineer who builds real systems and never forgets what I learn. This is Day 1 of that mission.

--- a/daily_stock.py
+++ b/daily_stock.py
@@ -1,0 +1,32 @@
+import datetime
+from dataclasses import dataclass
+from typing import Optional
+
+import yfinance as yf
+
+@dataclass
+class DailyStock:
+    symbol: str
+    close: float
+    date: datetime.date
+
+
+def fetch_latest_close(symbol: str, date: Optional[datetime.date] = None) -> DailyStock:
+    """Fetch the latest closing price for the given stock symbol."""
+    if date is None:
+        date = datetime.date.today()
+    data = yf.download(symbol, period="5d", interval="1d")
+    if data.empty:
+        raise ValueError(f"No data returned for symbol {symbol}")
+    last_row = data.tail(1).iloc[0]
+    close_price = float(last_row["Close"])
+    return DailyStock(symbol=symbol, close=close_price, date=last_row.name.date())
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Fetch daily closing stock price.")
+    parser.add_argument("symbol", help="Ticker symbol, e.g. AAPL")
+    args = parser.parse_args()
+    stock = fetch_latest_close(args.symbol)
+    print(f"{stock.symbol} closing price on {stock.date}: ${stock.close:.2f}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+yfinance>=0.2.0
+pandas>=1.0


### PR DESCRIPTION
## Summary
- add `daily_stock.py` for retrieving daily closing stock prices
- list new script in README
- describe usage instructions and Python requirements
- add requirements file for dependencies

## Testing
- `python -m py_compile daily_stock.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841848d49a48321a25faef0cd622b0c